### PR TITLE
Update wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,4 +7,5 @@ zone_id = ""
 
 [build]
 command = "npm install && npm run build"
-upload.format = "service-worker"
+[build.upload]
+format = "service-worker"


### PR DESCRIPTION
toml_edit (used by wrangler generate) doesn't support dotted table syntax, we need to always use the full table syntax in templates